### PR TITLE
feat: migrate ArchiveCompress to Data.From facility

### DIFF
--- a/src/main/java/io/kestra/plugin/compress/ArchiveCompress.java
+++ b/src/main/java/io/kestra/plugin/compress/ArchiveCompress.java
@@ -96,7 +96,6 @@ public class ArchiveCompress extends AbstractArchive implements RunnableTask<Arc
         title = Data.From.TITLE,
         description = Data.From.DESCRIPTION
     )
-    @PluginProperty(dynamic = true, additionalProperties = String.class)
     @NotNull
     private Object from;
 


### PR DESCRIPTION
This PR migrates `ArchiveCompress` to use the Data.From facility.

Closes kestra-io/kestra#12346

## What changes are being made and why?

The `ArchiveCompress` task used manual JSON parsing with `internalStorageURI = true`. This PR migrates to the standard Data.From pattern:

- **Implement `Data.From` interface** for consistency with other plugins
- **Replace manual parsing** with `Data.from().read()` reactive API
- **Remove `internalStorageURI` restriction** from `@PluginProperty`
- **Use standard documentation** with `Data.From.TITLE` and `Data.From.DESCRIPTION`
- **Add reactive processing** with `publishOn(Schedulers.boundedElastic())` for non-blocking I/O
- **Use `URIFetcher`** for file fetching (infrastructure for broader URI scheme support)

---

## How the changes have been QAed?

- ✅ All existing unit tests pass: `./gradlew test`
- ✅ Verified backward compatibility with `kestra://` URIs using HTTP Download → Compress flow

<img width="1242" height="701" alt="Screenshot 2025-10-27 at 8 04 01 PM" src="https://github.com/user-attachments/assets/7c671168-bfd9-4685-a679-3d789007db4c" />

