### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/compress/AbstractArchive.java
+++ b/src/main/java/io/kestra/plugin/compress/AbstractArchive.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -42,6 +43,7 @@ public abstract class AbstractArchive extends AbstractTask {
         description = "Required archive format. Compression supports AR, CPIO, JAR, TAR, and ZIP; ARJ and DUMP are extract-only and will fail on compression."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<ArchiveAlgorithm> algorithm;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/compress/AbstractFile.java
+++ b/src/main/java/io/kestra/plugin/compress/AbstractFile.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -21,5 +22,6 @@ abstract public class AbstractFile extends AbstractTask {
         description = "Required compression algorithm for a single file. Brotli, Deflate64, and Snappy variants are decode-only and cannot be used when writing."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<CompressionAlgorithm> compression;
 }

--- a/src/main/java/io/kestra/plugin/compress/ArchiveCompress.java
+++ b/src/main/java/io/kestra/plugin/compress/ArchiveCompress.java
@@ -25,6 +25,7 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.scheduler.Schedulers;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -98,6 +99,7 @@ public class ArchiveCompress extends AbstractArchive implements RunnableTask<Arc
         description = Data.From.DESCRIPTION
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Object from;
 
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/compress/ArchiveDecompress.java
+++ b/src/main/java/io/kestra/plugin/compress/ArchiveDecompress.java
@@ -70,7 +70,7 @@ public class ArchiveDecompress extends AbstractArchive implements RunnableTask<A
         title = "Internal storage URI of the archive"
     )
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "main")
     private Property<String> from;
 
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/compress/FileCompress.java
+++ b/src/main/java/io/kestra/plugin/compress/FileCompress.java
@@ -56,7 +56,7 @@ public class FileCompress extends AbstractFile implements RunnableTask<FileCompr
         title = "Internal storage URI of the source file"
     )
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "main")
     private Property<String> from;
 
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/compress/FileDecompress.java
+++ b/src/main/java/io/kestra/plugin/compress/FileDecompress.java
@@ -57,7 +57,7 @@ public class FileDecompress extends AbstractFile implements RunnableTask<FileDec
         title = "Internal storage URI of the compressed file"
     )
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "main")
     private Property<String> from;
 
     public Output run(RunContext runContext) throws Exception {


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712