### PR TITLE
docs(compress): add subgroup title and document encryption tasks

### DIFF
--- a/src/main/java/io/kestra/plugin/compress/package-info.java
+++ b/src/main/java/io/kestra/plugin/compress/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Compression",
     description = "This sub-group of plugins contains tasks for compressing, decompressing, encrypting, and decrypting files.",
     categories = {
         PluginSubGroup.PluginCategory.CORE

--- a/src/main/resources/doc/io.kestra.plugin.compress.md
+++ b/src/main/resources/doc/io.kestra.plugin.compress.md
@@ -1,6 +1,6 @@
 # How to use the Compress plugin
 
-Compress, decompress, archive, and extract files from Kestra flows.
+Compress, decompress, archive, extract, encrypt, and decrypt files from Kestra flows.
 
 ## Tasks
 
@@ -11,3 +11,7 @@ Compress, decompress, archive, and extract files from Kestra flows.
 `FileCompress` compresses a single file — set `from` (a `kestra://` URI) and `compression` (required). Supported algorithms: `GZIP`, `BZIP2`, `XZ`, `ZSTD`, `LZMA`, `DEFLATE`, `LZ4FRAME`, `LZ4BLOCK`, `SNAPPYFRAME`, `Z`, and others. Note: `BROTLI`, `DEFLATE64`, and `SNAPPY` variants are decode-only.
 
 `FileDecompress` decompresses a single file — set `from` and `compression`. Supports all algorithms including the decode-only ones.
+
+`FileEncrypt` encrypts a file with AES-256 — set `from` (a `kestra://` URI) and `password` (required; store it as a [secret](https://kestra.io/docs/concepts/secret)). The default `keyDerivation` (`PBKDF2_SHA256`) produces OpenSSL-compatible AES-256-CBC output (`openssl enc -aes-256-cbc -pbkdf2`); `PBKDF2_SHA512`, `ARGON2ID`, and `SCRYPT` use authenticated AES-256-GCM with a self-describing KESTRAENC file format. Tune the cost with `iterations` (PBKDF2), `argon2TimeCost`/`memory`/`parallelism` (Argon2id), or `memory`/`parallelism` (Scrypt).
+
+`FileDecrypt` decrypts a file produced by `FileEncrypt` — set `from` and `password`. The file format (OpenSSL or KESTRAENC) is detected automatically; for OpenSSL files, set `iterations` to match the value used at encrypt time.


### PR DESCRIPTION
## Documentation review: plugin-compress

Task-level doc pass over the six tasks (`ArchiveCompress`, `ArchiveDecompress`, `FileCompress`, `FileDecompress`, `FileEncrypt`, `FileDecrypt`), the shared abstracts, `index.yaml`, and the how-to doc. The plugin is well-documented; two gaps fixed. Documentation only.

### Fixes
- **`package-info.java`** — `@PluginSubGroup` was missing the `title` attribute → added `"Compression"` (matches `index.yaml`).
- **how-to doc** — the `## Tasks` section documented only the four compress/archive tasks; **`FileEncrypt` and `FileDecrypt` were entirely absent** (both exist and are described in the `index.yaml` body). Added entries for both (KDF options, OpenSSL vs KESTRAENC formats, `password` secret) and expanded the intro to mention encryption.

Everything else was accurate: all six task titles/descriptions and examples (passwords via `{{ secret('...') }}`), `password` correctly `@NotNull` + `secret = true`, `iterations` well documented, `ArchiveDecompress` `@Metric` (`size`/`count`) match emission, the extract-only/decode-only algorithm notes match the code, and the `index.yaml` body is thorough and correct. No code-level flags.