### PR TITLE
fix(compress): de-flake FileEncryptTest.wrongPasswordFails

### DIFF
--- a/src/test/java/io/kestra/plugin/compress/FileEncryptTest.java
+++ b/src/test/java/io/kestra/plugin/compress/FileEncryptTest.java
@@ -133,10 +133,21 @@ class FileEncryptTest {
             .iterations(Property.ofValue(100_000))
             .build();
 
-        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
-            decrypt.run(TestsUtils.mockRunContext(runContextFactory, decrypt, Map.of()))
-        );
-        assertThat(ex.getMessage().contains("Decryption failed"), is(true));
+        // The OpenSSL-compatible default is AES-CBC, which has no authentication tag: a wrong
+        // password is only detected when PKCS#7 unpadding fails, and random bytes pass that
+        // check about 1 time in 255. Either way the plaintext must not be recoverable.
+        try {
+            FileDecrypt.Output decOut = decrypt.run(TestsUtils.mockRunContext(runContextFactory, decrypt, Map.of()));
+
+            assertThat(
+                CharStreams.toString(new InputStreamReader(
+                    storageInterface.get(TenantService.MAIN_TENANT, null, decOut.getUri())
+                )),
+                not(is("secret data"))
+            );
+        } catch (IllegalStateException ex) {
+            assertThat(ex.getMessage().contains("Decryption failed"), is(true));
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

Makes `FileEncryptTest.wrongPasswordFails()` deterministic.

## Why

It failed on [run 30616241137](https://github.com/kestra-io/plugin-compress/actions/runs/30616241137) (a version-bump-only commit, no source change — the previous run on the identical tree was green):

```
org.opentest4j.AssertionFailedError: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
    at FileEncryptTest.wrongPasswordFails(FileEncryptTest.java:136)
```

The test uses the **default** key derivation, which is the OpenSSL-compatible path: `AES/CBC/PKCS5Padding` with no authentication tag (`AbstractFileCrypt.newCipher`, where CBC is deliberate for `openssl enc` interop). With a wrong password the derived key/IV are wrong, so the decrypted bytes are random — and the only thing that makes `FileDecrypt` throw is PKCS#7 unpadding failing. A random final block satisfies the padding check with probability ≈ Σ 256⁻ᵏ ≈ **1 in 255 (~0.4%)**, so the decrypt occasionally "succeeds" and returns garbage.

The three sibling cases (`wrongPasswordFailsArgon2id`, `…Pbkdf2Sha512`, `…Scrypt`) use the KESTRAENC format with AES-GCM, where the tag check is deterministic — which is why only this one flaked.

## How

Assert the security property that actually holds for an unauthenticated mode: decryption either throws `Decryption failed`, **or** it returns something that is not the original plaintext. No production code changes.

## Tests

`./gradlew test --tests 'io.kestra.plugin.compress.FileEncryptTest'` — 19 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)